### PR TITLE
fix(DI): inject Contexts for StackDetailsModule

### DIFF
--- a/projects/fabric8-stack-analysis-ui/src/lib/stack/card-details/report-information/report-information.module.ts
+++ b/projects/fabric8-stack-analysis-ui/src/lib/stack/card-details/report-information/report-information.module.ts
@@ -17,6 +17,7 @@ import { ToastNotificationModule } from '../../toast-notification/toast-notifica
 import { AddWorkFlowService } from '../../stack-details/add-work-flow.service';
 
 import { NoDataComponent } from './no-data/no-data.component';
+import { Contexts } from 'ngx-fabric8-wit';
 
 const components = [
     ComponentSnippetComponent,
@@ -41,7 +42,7 @@ const imports = [
     declarations: [
         ...components
     ],
-    providers: [ AddWorkFlowService ],
+    //providers: [ AddWorkFlowService, Contexts ],
     exports: [
         ...components
     ]

--- a/projects/fabric8-stack-analysis-ui/src/lib/stack/stack-details/stack-details.module.ts
+++ b/projects/fabric8-stack-analysis-ui/src/lib/stack/stack-details/stack-details.module.ts
@@ -21,6 +21,8 @@ import { CommonService } from '../utils/common.service';
 /** Stack Report Revamp - Latest */
 
 import { StackAnalysesService } from '../stack-analyses.service';
+import { AddWorkFlowService } from './add-work-flow.service';
+import { Contexts } from 'ngx-fabric8-wit';
 
 const revampImports = [
   ReportSummaryModule,
@@ -47,7 +49,7 @@ const revampImports = [
   providers: [
     GlobalConstants,
     CommonService,
-    StackAnalysesService
+    StackAnalysesService, AddWorkFlowService, Contexts
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })


### PR DESCRIPTION
@invincibleJai try injecting Contexts at upper Module. 
There is a bit of redundancy in AppModule:
- depends on StackDetailModule
- depends on StackReportInshortMocule (which in turn depends on StackDetailModule)